### PR TITLE
Fix VRS audit

### DIFF
--- a/client/vrsclient.go
+++ b/client/vrsclient.go
@@ -319,11 +319,13 @@ func (nvrsc *NuageVRSClient) auditOVSDB() error {
 			}
 
 			for _, portName := range portNames {
-				containerInfo[nuageConfig.BridgePortKey] = portName
-				containerInfo[nuageConfig.UUIDKey] = entity
-				err := nvrsc.deleteEntries(containerInfo)
-				if err != nil {
-					log.Errorf("Deleting entries in audit failed with error %v", err)
+				if strings.HasPrefix(portName, nuageConfig.BasePrefix) { //manage ports with only libnetwork prefix
+					containerInfo[nuageConfig.BridgePortKey] = portName
+					containerInfo[nuageConfig.UUIDKey] = entity
+					err := nvrsc.deleteEntries(containerInfo)
+					if err != nil {
+						log.Errorf("Deleting entries in audit failed with error %v", err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixing the issue where libnetwork deletes vrs vports that are not managed by plugin